### PR TITLE
Add support for plugins configuration, add more plugins, refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: Run Nix checks
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run disabled check
+        run: nix build .#checks.$(uname -m)-darwin.disabled -L
+
+      - name: Run withoutDirenv check
+        run: nix build .#checks.$(uname -m)-darwin.withoutDirenv -L
+
+      - name: Run withDirenv check
+        run: nix build .#checks.$(uname -m)-darwin.withDirenv -L
+
+      - name: Run withNodejs check
+        run: nix build .#checks.$(uname -m)-darwin.withNodejs -L
+
+      - name: Run withGolang check
+        run: nix build .#checks.$(uname -m)-darwin.withGolang -L
+
+      - name: Run withTerraform check
+        run: nix build .#checks.$(uname -m)-darwin.withTerraform -L
+
+      - name: Run withOpenTofu check
+        run: nix build .#checks.$(uname -m)-darwin.withOpenTofu -L
+
+      - name: Run withRuby check
+        run: nix build .#checks.$(uname -m)-darwin.withRuby -L
+
+      - name: Run withPython check
+        run: nix build .#checks.$(uname -m)-darwin.withPython -L
+
+      - name: Run withMultiplePlugins check
+        run: nix build .#checks.$(uname -m)-darwin.withMultiplePlugins -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,32 +28,11 @@ jobs:
             experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run disabled check
-        run: nix build .#checks.$(uname -m)-darwin.disabled -L
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run withoutDirenv check
-        run: nix build .#checks.$(uname -m)-darwin.withoutDirenv -L
-
-      - name: Run withDirenv check
-        run: nix build .#checks.$(uname -m)-darwin.withDirenv -L
-
-      - name: Run withNodejs check
-        run: nix build .#checks.$(uname -m)-darwin.withNodejs -L
-
-      - name: Run withGolang check
-        run: nix build .#checks.$(uname -m)-darwin.withGolang -L
-
-      - name: Run withTerraform check
-        run: nix build .#checks.$(uname -m)-darwin.withTerraform -L
-
-      - name: Run withOpenTofu check
-        run: nix build .#checks.$(uname -m)-darwin.withOpenTofu -L
-
-      - name: Run withRuby check
-        run: nix build .#checks.$(uname -m)-darwin.withRuby -L
-
-      - name: Run withPython check
-        run: nix build .#checks.$(uname -m)-darwin.withPython -L
-
-      - name: Run withMultiplePlugins check
-        run: nix build .#checks.$(uname -m)-darwin.withMultiplePlugins -L
+      - name: Run all checks
+        run: nix flake check -L --keep-going

--- a/README.md
+++ b/README.md
@@ -9,5 +9,63 @@ A way to configure asdf using NIX and home-manager.
 ## Why
 For times when working on projects that have not fully embraced NIX.
 
+## Features
+
+### Supported Plugins
+The following plugins are currently supported with declarative configuration:
+
+- NodeJS (with default packages support)
+- Ruby (with default packages support)
+- Python (with default packages support)
+- Terraform
+- OpenTofu
+- Golang
+- Skaffold
+- Kubectl
+- Kustomize
+
+### Key Benefits
+
+- **Declarative Configuration**: Define your development environment in code
+- **Version Consistency**: Ensure consistent tool versions across your team
+- **Integration with Home Manager**: Seamlessly works with your existing Nix setup
+- **Default Packages**: Automatically install default packages for supported languages
+- **Tool Versions**: Automatically generates `.tool-versions` file based on your configuration
+
+### Example Configuration
+
+```nix
+programs.asdf = {
+  enable = true;
+  
+  nodejs = {
+    enable = true;
+    defaultVersion = "22.14.0";
+    defaultPackages = [
+      "yarn"
+      "pnpm"
+    ];
+  };
+  
+  golang = {
+    enable = true;
+    defaultVersion = "1.24.3";
+  };
+  
+  ruby = {
+    enable = true;
+    defaultVersion = "3.4.2";
+  };
+};
+```
+
+## Implementation Details
+
+- Uses the official asdf-vm package from nixpkgs
+- Installs plugins and tool versions during home-manager activation
+- Manages plugin lifecycle (installation and removal)
+- Generates configuration files (.tool-versions, .default-*-packages)
+- Includes direnv integration for project-specific environments
+
 **NOTE**
 Not all plugins are currently included but the plugin install folder is not readonly so normal ASDF plugin install should work

--- a/README.md
+++ b/README.md
@@ -59,6 +59,41 @@ programs.asdf = {
 };
 ```
 
+## Development
+
+### Running Tests
+
+This project uses [Task](https://taskfile.dev) to run tests locally. To run all tests:
+
+```bash
+# Install Task if you don't have it
+brew install go-task
+
+# Run all tests
+task check:all
+
+# Run a specific test
+task check:withGolang
+```
+
+Available test tasks:
+
+- `check:all` - Run all checks
+- `check:disabled` - Test with ASDF disabled
+- `check:withoutDirenv` - Test ASDF without direnv
+- `check:withDirenv` - Test ASDF with direnv
+- `check:withNodejs` - Test NodeJS plugin
+- `check:withGolang` - Test Golang plugin
+- `check:withTerraform` - Test Terraform plugin
+- `check:withOpenTofu` - Test OpenTofu plugin
+- `check:withRuby` - Test Ruby plugin
+- `check:withPython` - Test Python plugin
+- `check:withMultiplePlugins` - Test multiple plugins together
+
+### CI Pipeline
+
+The project uses GitHub Actions for continuous integration. The CI pipeline runs all tests on macOS to ensure compatibility.
+
 ## Implementation Details
 
 - Uses the official asdf-vm package from nixpkgs

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,78 @@
+version: '3'
+
+tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list
+
+  check:all:
+    desc: Run all checks
+    cmds:
+      - nix build .#homeManagerModules.default --dry-run
+      - echo "✅ Module builds successfully"
+      - task: check:golang
+      - task: check:terraform
+      - task: check:opentofu
+      - task: check:ruby
+      - task: check:python
+      - task: check:multiple
+
+  check:golang:
+    desc: Verify Golang plugin configuration
+    cmds:
+      - |
+        echo "Checking Golang plugin configuration..."
+        grep -q "golang = {" asdf.nix && 
+        grep -q "defaultVersion = \"1.24.3\"" asdf.nix && 
+        grep -q "asdf plugin add \"golang\" https://github.com/asdf-community/asdf-golang.git" asdf.nix &&
+        echo "✅ Golang plugin configuration verified"
+
+  check:terraform:
+    desc: Verify Terraform plugin configuration
+    cmds:
+      - |
+        echo "Checking Terraform plugin configuration..."
+        grep -q "terraform = {" asdf.nix && 
+        grep -q "terraform" asdf.nix &&
+        echo "✅ Terraform plugin configuration verified"
+
+  check:opentofu:
+    desc: Verify OpenTofu plugin configuration
+    cmds:
+      - |
+        echo "Checking OpenTofu plugin configuration..."
+        grep -q "opentofu = {" asdf.nix && 
+        grep -q "opentofu" asdf.nix &&
+        echo "✅ OpenTofu plugin configuration verified"
+
+  check:ruby:
+    desc: Verify Ruby plugin configuration
+    cmds:
+      - |
+        echo "Checking Ruby plugin configuration..."
+        grep -q "ruby = {" asdf.nix && 
+        grep -q "ruby" asdf.nix &&
+        echo "✅ Ruby plugin configuration verified"
+
+  check:python:
+    desc: Verify Python plugin configuration
+    cmds:
+      - |
+        echo "Checking Python plugin configuration..."
+        grep -q "python = {" asdf.nix && 
+        grep -q "python" asdf.nix &&
+        echo "✅ Python plugin configuration verified"
+
+  check:multiple:
+    desc: Verify multiple plugins support
+    cmds:
+      - |
+        echo "Checking multiple plugins support..."
+        grep -q "supportedPlugins = \[" asdf.nix &&
+        grep -q "\"golang\"" asdf.nix &&
+        grep -q "\"terraform\"" asdf.nix &&
+        grep -q "\"opentofu\"" asdf.nix &&
+        grep -q "\"ruby\"" asdf.nix &&
+        grep -q "\"python\"" asdf.nix &&
+        echo "✅ Multiple plugins support verified"

--- a/asdf.nix
+++ b/asdf.nix
@@ -1,12 +1,14 @@
-{ config, lib, pkgs, ... }:
-with lib;
-let
-  cfg = config.asdf;
-in
 {
-  options.asdf = {
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.programs.asdf;
+in {
+  options.programs.asdf = {
     enable = mkEnableOption "ASDF Version Manager";
-    direnv = mkEnableOption "Use direnv";
 
     package = mkOption {
       type = types.package;
@@ -14,66 +16,340 @@ in
       default = pkgs.asdf-vm;
     };
 
+    # Automatically set plugins based on enabled configuration
+    plugins = mkOption {
+      type = with types; listOf str;
+      description = "Plugins to install";
+      default = [];
+      example = [
+        "nodejs"
+        "python"
+      ];
+    };
+
+    direnv = mkOption {
+      description = "Direnv";
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "Enable direnv integration";
+        };
+      };
+      default = {};
+    };
+
     nodejs = mkOption {
       description = "Nodejs";
       type = types.submodule {
         options = {
           enable = mkEnableOption "Enable Nodejs plugin";
-          npmDefaultPackages = mkOption {
+          defaultPackages = mkOption {
             type = with types; listOf str;
-            description = "What npm packages to install by default";
-            default = [ ];
+            description = "Packages to install by default";
+            default = [];
+          };
+
+          defaultVersion = mkOption {
+            type = types.str;
+            description = "Default System version to install";
+            default = "22.14.0";
           };
         };
       };
-      default = { };
+      default = {};
     };
 
-    plugins = mkOption {
-      type = with types; listOf (enum [
-        "direnv"
-        "nodejs"
-        "skaffold"
-        "kubectl"
-        "kustomize"
-      ]);
-      description = "What plugins to install";
-      default = [ ];
+    ruby = mkOption {
+      description = "Ruby";
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "Enable Ruby plugin";
+          defaultPackages = mkOption {
+            type = with types; listOf str;
+            description = "Packages to install by default";
+            default = [];
+          };
+
+          defaultVersion = mkOption {
+            type = types.str;
+            description = "Default System version to install";
+            default = "3.4.2";
+          };
+        };
+      };
+      default = {};
+    };
+
+    python = mkOption {
+      description = "Python";
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "Enable Python plugin";
+          defaultPackages = mkOption {
+            type = with types; listOf str;
+            description = "Packages to install by default";
+            default = "";
+          };
+
+          defaultVersion = mkOption {
+            type = types.str;
+            description = "Default System version to install";
+            default = "3.13.2";
+          };
+        };
+      };
+      default = {};
+    };
+
+    terraform = mkOption {
+      description = "Terraform";
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "Enable Terraform plugin";
+          defaultVersion = mkOption {
+            type = types.str;
+            description = "Default System version to install";
+            default = "1.5.5";
+          };
+        };
+      };
+      default = {};
+    };
+
+    opentofu = mkOption {
+      description = "OpenTofu";
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "Enable OpenTofu plugin";
+          defaultVersion = mkOption {
+            type = types.str;
+            description = "Default System version to install";
+            default = "1.9.0";
+          };
+        };
+      };
+      default = {};
+    };
+
+    golang = mkOption {
+      description = "Golang";
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "Enable Golang plugin";
+          defaultVersion = mkOption {
+            type = types.str;
+            description = "Default System version to install";
+            default = "1.24.3";
+          };
+        };
+      };
+      default = {};
+    };
+
+    skaffold = mkOption {
+      description = "Skaffold";
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "Enable Skaffold plugin";
+        };
+      };
+      default = {};
+    };
+
+    kubectl = mkOption {
+      description = "Kubectl";
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "Enable Kubectl plugin";
+        };
+      };
+      default = {};
+    };
+
+    kustomize = mkOption {
+      description = "Kustomize";
+      type = types.submodule {
+        options = {
+          enable = mkEnableOption "Enable Kustomize plugin";
+        };
+      };
+      default = {};
+    };
+
+    config = mkOption {
+      type = types.attrsOf types.str;
+      description = "Settings that would be placed in the .asdfrc file";
+      default = {};
     };
   };
-  config = mkIf cfg.enable (
-    mkMerge [{
+
+  config = mkIf cfg.enable (mkMerge [
+    {
+      programs.asdf.plugins = let
+        isPluginEnabled = name:
+          builtins.hasAttr name cfg
+          && builtins.isAttrs cfg.${name}
+          && builtins.hasAttr "enable" cfg.${name}
+          && cfg.${name}.enable;
+
+        supportedPlugins = [
+          "nodejs"
+          "python"
+          "ruby"
+          "skaffold"
+          "kubectl"
+          "kustomize"
+          "terraform"
+          "opentofu"
+          "golang"
+        ];
+        enabledPlugins = builtins.filter isPluginEnabled supportedPlugins;
+      in
+        enabledPlugins;
+
       home = {
         packages = [
-          config.asdf.package
+          cfg.package
+
+          pkgs.git
+          pkgs.gawk
+          pkgs.gnutar
+          pkgs.gzip
+          pkgs.libyaml
+          pkgs.libyaml.dev
+          pkgs.openssl
+          pkgs.openssl.dev
         ];
+
+        file = mkMerge [
+          (
+            let
+              toolVersions =
+                []
+                ++ (optional (cfg.nodejs.enable && cfg.nodejs.defaultVersion != "") "nodejs ${cfg.nodejs.defaultVersion}")
+                ++ (optional (cfg.ruby.enable && cfg.ruby.defaultVersion != "") "ruby ${cfg.ruby.defaultVersion}")
+                ++ (optional (cfg.python.enable && cfg.python.defaultVersion != "") "python ${cfg.python.defaultVersion}")
+                ++ (optional (cfg.terraform.enable && cfg.terraform.defaultVersion != "") "terraform ${cfg.terraform.defaultVersion}")
+                ++ (optional (cfg.opentofu.enable && cfg.opentofu.defaultVersion != "") "terraform ${cfg.opentofu.defaultVersion}")
+                ++ (optional (cfg.golang.enable && cfg.golang.defaultVersion != "") "golang ${cfg.golang.defaultVersion}");
+            in
+              mkIf (toolVersions != []) {
+                ".tool-versions" = {
+                  text = concatStringsSep "\n" toolVersions + "\n";
+                };
+              }
+          )
+
+          (mkIf (cfg.config != {}) {
+            ".asdfrc" = {
+              text = builtins.concatStringsSep "\n" (mapAttrsToList (k: v: "${k} = ${v}") cfg.config);
+            };
+          })
+        ];
+
+        # Add activation script to install plugins
+        activation.installAsdfPlugins = hm.dag.entryAfter ["writeBoundary" "linkGeneration"] (
+          let
+            # Filter out non-package items and create path stringf
+            packageBinPaths = concatStringsSep ":" (
+              map (pkg: "${pkg}/bin") (
+                builtins.filter (p: p ? type && p.type == "derivation") config.home.packages
+              )
+            );
+
+            packageLibnPaths = concatStringsSep ":" (
+              map (pkg: "${pkg}/lib") (
+                builtins.filter (p: p ? type && p.type == "derivation") config.home.packages
+              )
+            );
+          in ''
+            # Ensure PATH includes home-manager paths
+            export PATH="${config.home.profileDirectory}/bin:${packageBinPaths}:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:$PATH"
+
+            export MAKE_OPTS=-j$(nproc)
+            export RUBY_CONFIGURE_OPTS="--with-libyaml-dir=${pkgs.libyaml.dev}" # This is required for ruby to discover libyaml
+
+
+            if [ -x "${cfg.package}/bin/asdf" ]; then
+              echo "Managing ASDF plugins..."
+
+              # Get currently installed plugins
+              installed_plugins=$(${cfg.package}/bin/asdf plugin list 2>/dev/null || echo "")
+
+              # Install configured plugins
+              ${concatMapStringsSep "\n" (plugin: ''
+                if ! echo "$installed_plugins" | grep -q "^${plugin}$"; then
+                  echo "Installing plugin: ${plugin}"
+                  ${if plugin == "golang" then ''
+                    ${cfg.package}/bin/asdf plugin add "${plugin}" https://github.com/asdf-community/asdf-golang.git
+                  '' else ''
+                    ${cfg.package}/bin/asdf plugin add "${plugin}"
+                  ''}
+                fi
+              '')
+              cfg.plugins}
+
+              # Install configured tool versions
+              if [ -f "$HOME/.tool-versions" ]; then
+                echo "Installing configured tool versions..."
+                ${cfg.package}/bin/asdf install
+              fi
+
+              # Remove plugins that are not configured
+              if [ -n "$installed_plugins" ]; then
+                echo "$installed_plugins" | while read -r plugin; do
+                  if [[ -n "$plugin" ]] && ! echo "${concatStringsSep " " cfg.plugins}" | grep -q "$plugin"; then
+                    echo "Removing unused plugin: $plugin"
+                    ${cfg.package}/bin/asdf plugin remove "$plugin"
+                  fi
+                done
+              fi
+            fi
+          ''
+        );
       };
     }
-      (mkIf cfg.nodejs.enable {
-        home = {
-          file = mkIf ((builtins.length cfg.nodejs.npmDefaultPackages) > 0) {
-            ".default-npm-packages".text = builtins.concatStringsSep "\n" cfg.nodejs.npmDefaultPackages;
-          };
-          sessionVariables = {
-            ASDF_NODEJS_NODEBUILD_HOME = "$HOME/.asdf/build/node-build";
-          };
+
+    (mkIf cfg.nodejs.enable {
+      home = {
+        file = mkMerge [
+          (mkIf ((builtins.length cfg.nodejs.defaultPackages) > 0) {
+            ".default-npm-packages".text = builtins.concatStringsSep "\n" cfg.nodejs.defaultPackages;
+          })
+        ];
+
+        sessionVariables = {
+          ASDF_NODEJS_NODEBUILD_HOME = "$HOME/.asdf/build/node-build";
         };
-        asdf = {
-          plugins = [ "nodejs" ];
+      };
+    })
+
+    (mkIf cfg.python.enable {
+      home = {
+        file = mkIf ((builtins.length cfg.python.defaultPackages) > 0) {
+          ".default-python-packages".text = builtins.concatStringsSep "\n" cfg.python.defaultPackages;
         };
-      })
-      (mkIf cfg.direnv {
-        asdf.plugins = [ "direnv" ];
-        programs = {
-          direnv = {
-            enable = true;
-            stdlib = ''
-              use_asdf() {
-                source_env "$(asdf direnv envrc "$@")"
-              }
-            '';
-          };
+      };
+    })
+
+    (mkIf cfg.ruby.enable {
+      home = {
+        file = mkIf ((builtins.length cfg.ruby.defaultPackages) > 0) {
+          ".default-ruby-packages".text = builtins.concatStringsSep "\n" cfg.ruby.defaultPackages;
         };
-      })]
-  );
+      };
+    })
+
+    (mkIf cfg.direnv.enable {
+      programs = {
+        direnv = {
+          enable = true;
+          stdlib = ''
+            use_asdf() {
+              source_env "$(asdf direnv envrc "$@")"
+            }
+          '';
+        };
+      };
+    })
+  ]);
 }

--- a/checks.nix
+++ b/checks.nix
@@ -129,4 +129,286 @@ in
       })
     ];
   }).system;
+  
+  withGolang = (darwin.lib.darwinSystem {
+    inherit system;
+
+    modules = [
+      home-manager.darwinModules.home-manager
+      self.nixosModule
+      ({ config, pkgs, lib, ... }: {
+        home-manager.useGlobalPkgs = true;
+        users.users.test = { };
+        home-manager.users.test = {
+          home.stateVersion = "21.11";
+          asdf = {
+            enable = true;
+            golang = {
+              enable = true;
+              defaultVersion = "1.24.3";
+            };
+          };
+        };
+        assertions = [
+          {
+            assertion = hasPackage "asdf-vm" config;
+            message = "ASDF should be included as a package";
+          }
+          {
+            assertion = lib.elem "golang" config.home-manager.users.test.programs.asdf.plugins;
+            message = "Golang plugin should be enabled";
+          }
+          {
+            assertion = lib.strings.hasInfix "golang 1.24.3" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "Golang version should be set in .tool-versions";
+          }
+        ];
+      })
+    ];
+  }).system;
+  
+  withTerraform = (darwin.lib.darwinSystem {
+    inherit system;
+
+    modules = [
+      home-manager.darwinModules.home-manager
+      self.nixosModule
+      ({ config, pkgs, lib, ... }: {
+        home-manager.useGlobalPkgs = true;
+        users.users.test = { };
+        home-manager.users.test = {
+          home.stateVersion = "21.11";
+          asdf = {
+            enable = true;
+            terraform = {
+              enable = true;
+              defaultVersion = "1.5.5";
+            };
+          };
+        };
+        assertions = [
+          {
+            assertion = hasPackage "asdf-vm" config;
+            message = "ASDF should be included as a package";
+          }
+          {
+            assertion = lib.elem "terraform" config.home-manager.users.test.programs.asdf.plugins;
+            message = "Terraform plugin should be enabled";
+          }
+          {
+            assertion = lib.strings.hasInfix "terraform 1.5.5" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "Terraform version should be set in .tool-versions";
+          }
+        ];
+      })
+    ];
+  }).system;
+  
+  withOpenTofu = (darwin.lib.darwinSystem {
+    inherit system;
+
+    modules = [
+      home-manager.darwinModules.home-manager
+      self.nixosModule
+      ({ config, pkgs, lib, ... }: {
+        home-manager.useGlobalPkgs = true;
+        users.users.test = { };
+        home-manager.users.test = {
+          home.stateVersion = "21.11";
+          asdf = {
+            enable = true;
+            opentofu = {
+              enable = true;
+              defaultVersion = "1.9.0";
+            };
+          };
+        };
+        assertions = [
+          {
+            assertion = hasPackage "asdf-vm" config;
+            message = "ASDF should be included as a package";
+          }
+          {
+            assertion = lib.elem "opentofu" config.home-manager.users.test.programs.asdf.plugins;
+            message = "OpenTofu plugin should be enabled";
+          }
+          {
+            assertion = lib.strings.hasInfix "terraform 1.9.0" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "OpenTofu version should be set in .tool-versions as terraform";
+          }
+        ];
+      })
+    ];
+  }).system;
+  
+  withRuby = (darwin.lib.darwinSystem {
+    inherit system;
+
+    modules = [
+      home-manager.darwinModules.home-manager
+      self.nixosModule
+      ({ config, pkgs, lib, ... }: {
+        home-manager.useGlobalPkgs = true;
+        users.users.test = { };
+        home-manager.users.test = {
+          home.stateVersion = "21.11";
+          asdf = {
+            enable = true;
+            ruby = {
+              enable = true;
+              defaultVersion = "3.4.2";
+              defaultPackages = [ "bundler" "pry" ];
+            };
+          };
+        };
+        assertions = [
+          {
+            assertion = hasPackage "asdf-vm" config;
+            message = "ASDF should be included as a package";
+          }
+          {
+            assertion = lib.elem "ruby" config.home-manager.users.test.programs.asdf.plugins;
+            message = "Ruby plugin should be enabled";
+          }
+          {
+            assertion = lib.strings.hasInfix "ruby 3.4.2" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "Ruby version should be set in .tool-versions";
+          }
+          {
+            assertion = lib.strings.hasInfix "bundler" (builtins.readFile config.home-manager.users.test.home.file.".default-ruby-packages".source);
+            message = "Ruby default packages should be set";
+          }
+        ];
+      })
+    ];
+  }).system;
+  
+  withPython = (darwin.lib.darwinSystem {
+    inherit system;
+
+    modules = [
+      home-manager.darwinModules.home-manager
+      self.nixosModule
+      ({ config, pkgs, lib, ... }: {
+        home-manager.useGlobalPkgs = true;
+        users.users.test = { };
+        home-manager.users.test = {
+          home.stateVersion = "21.11";
+          asdf = {
+            enable = true;
+            python = {
+              enable = true;
+              defaultVersion = "3.13.2";
+              defaultPackages = [ "pip" "pytest" ];
+            };
+          };
+        };
+        assertions = [
+          {
+            assertion = hasPackage "asdf-vm" config;
+            message = "ASDF should be included as a package";
+          }
+          {
+            assertion = lib.elem "python" config.home-manager.users.test.programs.asdf.plugins;
+            message = "Python plugin should be enabled";
+          }
+          {
+            assertion = lib.strings.hasInfix "python 3.13.2" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "Python version should be set in .tool-versions";
+          }
+          {
+            assertion = lib.strings.hasInfix "pip" (builtins.readFile config.home-manager.users.test.home.file.".default-python-packages".source);
+            message = "Python default packages should be set";
+          }
+        ];
+      })
+    ];
+  }).system;
+  
+  withMultiplePlugins = (darwin.lib.darwinSystem {
+    inherit system;
+
+    modules = [
+      home-manager.darwinModules.home-manager
+      self.nixosModule
+      ({ config, pkgs, lib, ... }: {
+        home-manager.useGlobalPkgs = true;
+        users.users.test = { };
+        home-manager.users.test = {
+          home.stateVersion = "21.11";
+          asdf = {
+            enable = true;
+            direnv = true;
+            nodejs = {
+              enable = true;
+              defaultVersion = "22.14.0";
+              defaultPackages = [ "yarn" ];
+            };
+            golang = {
+              enable = true;
+              defaultVersion = "1.24.3";
+            };
+            ruby = {
+              enable = true;
+              defaultVersion = "3.4.2";
+            };
+            python = {
+              enable = true;
+              defaultVersion = "3.13.2";
+            };
+            terraform = {
+              enable = true;
+              defaultVersion = "1.5.5";
+            };
+          };
+        };
+        assertions = [
+          {
+            assertion = hasPackage "asdf-vm" config;
+            message = "ASDF should be included as a package";
+          }
+          {
+            assertion = lib.elem "nodejs" config.home-manager.users.test.programs.asdf.plugins;
+            message = "NodeJS plugin should be enabled";
+          }
+          {
+            assertion = lib.elem "golang" config.home-manager.users.test.programs.asdf.plugins;
+            message = "Golang plugin should be enabled";
+          }
+          {
+            assertion = lib.elem "ruby" config.home-manager.users.test.programs.asdf.plugins;
+            message = "Ruby plugin should be enabled";
+          }
+          {
+            assertion = lib.elem "python" config.home-manager.users.test.programs.asdf.plugins;
+            message = "Python plugin should be enabled";
+          }
+          {
+            assertion = lib.elem "terraform" config.home-manager.users.test.programs.asdf.plugins;
+            message = "Terraform plugin should be enabled";
+          }
+          {
+            assertion = lib.strings.hasInfix "nodejs 22.14.0" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "NodeJS version should be set in .tool-versions";
+          }
+          {
+            assertion = lib.strings.hasInfix "golang 1.24.3" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "Golang version should be set in .tool-versions";
+          }
+          {
+            assertion = lib.strings.hasInfix "ruby 3.4.2" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "Ruby version should be set in .tool-versions";
+          }
+          {
+            assertion = lib.strings.hasInfix "python 3.13.2" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "Python version should be set in .tool-versions";
+          }
+          {
+            assertion = lib.strings.hasInfix "terraform 1.5.5" (builtins.readFile config.home-manager.users.test.home.file.".tool-versions".source);
+            message = "Terraform version should be set in .tool-versions";
+          }
+        ];
+      })
+    ];
+  }).system;
 }

--- a/checks.nix
+++ b/checks.nix
@@ -5,7 +5,6 @@ in
 {
   disabled = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -33,7 +32,6 @@ in
   }).system;
   withoutDirenv = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -42,7 +40,7 @@ in
         users.users.test = { };
         home-manager.users.test = {
           home.stateVersion = "21.11";
-          asdf = {
+          programs.asdf = {
             enable = true;
           };
         };
@@ -61,7 +59,6 @@ in
   }).system;
   withDirenv = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -70,9 +67,11 @@ in
         users.users.test = { };
         home-manager.users.test = {
           home.stateVersion = "21.11";
-          asdf = {
+          programs.asdf = {
             enable = true;
-            direnv = true;
+            direnv = {
+              enable = true;
+            };
           };
         };
         assertions = [
@@ -94,7 +93,6 @@ in
   }).system;
   withNodejs = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -103,12 +101,14 @@ in
         users.users.test = { };
         home-manager.users.test = {
           home.stateVersion = "21.11";
-          asdf = {
+          programs.asdf = {
             enable = true;
-            direnv = true;
+            direnv = {
+              enable = true;
+            };
             nodejs = {
               enable = true;
-              npmDefaultPackages = [ "yarn" ];
+              defaultPackages = [ "yarn" ];
             };
           };
         };
@@ -132,7 +132,6 @@ in
   
   withGolang = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -141,7 +140,7 @@ in
         users.users.test = { };
         home-manager.users.test = {
           home.stateVersion = "21.11";
-          asdf = {
+          programs.asdf = {
             enable = true;
             golang = {
               enable = true;
@@ -169,7 +168,6 @@ in
   
   withTerraform = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -178,7 +176,7 @@ in
         users.users.test = { };
         home-manager.users.test = {
           home.stateVersion = "21.11";
-          asdf = {
+          programs.asdf = {
             enable = true;
             terraform = {
               enable = true;
@@ -206,7 +204,6 @@ in
   
   withOpenTofu = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -215,7 +212,7 @@ in
         users.users.test = { };
         home-manager.users.test = {
           home.stateVersion = "21.11";
-          asdf = {
+          programs.asdf = {
             enable = true;
             opentofu = {
               enable = true;
@@ -243,7 +240,6 @@ in
   
   withRuby = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -252,7 +248,7 @@ in
         users.users.test = { };
         home-manager.users.test = {
           home.stateVersion = "21.11";
-          asdf = {
+          programs.asdf = {
             enable = true;
             ruby = {
               enable = true;
@@ -285,7 +281,6 @@ in
   
   withPython = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -294,7 +289,7 @@ in
         users.users.test = { };
         home-manager.users.test = {
           home.stateVersion = "21.11";
-          asdf = {
+          programs.asdf = {
             enable = true;
             python = {
               enable = true;
@@ -327,7 +322,6 @@ in
   
   withMultiplePlugins = (darwin.lib.darwinSystem {
     inherit system;
-
     modules = [
       home-manager.darwinModules.home-manager
       self.nixosModule
@@ -336,9 +330,11 @@ in
         users.users.test = { };
         home-manager.users.test = {
           home.stateVersion = "21.11";
-          asdf = {
+          programs.asdf = {
             enable = true;
-            direnv = true;
+            direnv = {
+              enable = true;
+            };
             nodejs = {
               enable = true;
               defaultVersion = "22.14.0";

--- a/flake.lock
+++ b/flake.lock
@@ -7,15 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1648278671,
-        "narHash": "sha256-1WrR9ex+rKTjZtODNUZQhkWYUprtfOkjOyo9YWL2NMs=",
+        "lastModified": 1743127615,
+        "narHash": "sha256-+sMGqywrSr50BGMLMeY789mSrzjkoxZiu61eWjYS/8o=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "4fdbb8168f61d31d3f90bb0d07f48de709c4fe79",
+        "rev": "fc843893cecc1838a59713ee3e50e9e7edc6207c",
         "type": "github"
       },
       "original": {
         "owner": "LnL7",
+        "ref": "nix-darwin-24.11",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -42,32 +43,34 @@
         ]
       },
       "locked": {
-        "lastModified": 1648834319,
-        "narHash": "sha256-i5Aj4Aw64D/A0X6XW5LxSS4XBnYj7gMz+kN4dpsbdk8=",
+        "lastModified": 1747688870,
+        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0bdbdea2e26c984b096f4f7d10e3c88536a980b0",
+        "rev": "d5f1f641b289553927b3801580598d200a501863",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-21.11",
+        "ref": "release-24.11",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1648219316,
-        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "plugin-direnv": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,12 @@
 
   inputs = {
     darwin = {
-      url = "github:LnL7/nix-darwin";
+      url = "github:LnL7/nix-darwin/nix-darwin-24.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-21.11";
+      url = "github:nix-community/home-manager/release-24.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -39,50 +39,28 @@
       url = "github:Banno/asdf-kustomize";
       flake = false;
     };
-
   };
-  outputs = inputs@{ self, darwin, home-manager, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachSystem [
-      flake-utils.lib.system.x86_64-darwin
-      flake-utils.lib.system.aarch64-darwin
-    ]
-      (system:
-        let
-          p = import nixpkgs {
-            inherit system;
-          };
-        in
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      home-manager,
+      flake-utils,
+      ...
+    }:
+    {
+      homeManagerModules.default = import ./asdf.nix;
+
+      darwinModules.default =
+        {
+          pkgs,
+
+          ...
+        }:
         {
 
-          checks = (import ./checks.nix) {
-            lib = nixpkgs.lib;
-            inherit
-              darwin
-              system
-              home-manager
-              self;
-          };
-          devShell = (import ./shell.nix) {
-            pkgs = p;
-          };
-        }
-      ) // {
-      nixosModule = {
-        home-manager.sharedModules = [
-          ./asdf.nix
-          ({ config, lib, pkgs, ... }:
-            {
-              home.file = builtins.listToAttrs
-                (builtins.map
-                  (x: {
-                    name = ".asdf/plugins/${x}";
-                    value = {
-                      source = inputs."plugin-${x}";
-                    };
-                  })
-                  config.asdf.plugins);
-            })
-        ];
-      };
+        };
     };
+
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,8 @@
   description = "ASDF for nix";
 
   inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin";
+    
     darwin = {
       url = "github:LnL7/nix-darwin/nix-darwin-24.11";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -45,22 +47,28 @@
     {
       self,
       nixpkgs,
+      darwin,
       home-manager,
       flake-utils,
       ...
     }:
-    {
+    flake-utils.lib.eachDefaultSystem (system: {
+      nixosModule = self.homeManagerModules.default;
+      
+      checks = import ./checks.nix {
+        inherit self darwin system home-manager;
+        lib = nixpkgs.lib;
+      };
+    }) // {
       homeManagerModules.default = import ./asdf.nix;
 
       darwinModules.default =
         {
           pkgs,
-
           ...
         }:
         {
 
         };
     };
-
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,10 @@
 { pkgs ? import <nixpkgs> }:
 pkgs.mkShell {
+ packages = with pkgs; [
+    libyaml
+    openssl
+  ];
   buildInputs = [
+
   ];
 }


### PR DESCRIPTION
# Changes
Large refactor to support plugin config
- feat(readme): Document supported plugins and key benefits
- feat(asdf.nix): Add options for multiple programming languages (NodeJS, Ruby, Python, Terraform, OpenTofu, Golang, Skaffold, Kubectl, Kustomize)
- chore(shell.nix): Include additional required packages (libyaml, openssl)
- chore(ci.yml): Create CI workflow for Nix checks
- test(checks.nix): Add assertions for each programming language plugin and version checks