### PR TITLE
Add skipPluginSync and compile-time library paths for container support

### DIFF
--- a/asdf.nix
+++ b/asdf.nix
@@ -261,9 +261,26 @@ in {
                 builtins.filter (p: p ? type && p.type == "derivation") config.home.packages
               )
             );
+            packageIncludePaths = concatStringsSep ":" (
+              map (pkg: "${pkg}/include") (
+                builtins.filter (p: p ? type && p.type == "derivation") config.home.packages
+              )
+            );
+
+            packagePkgConfigPaths = concatStringsSep ":" (
+              map (pkg: "${pkg}/lib/pkgconfig") (
+                builtins.filter (p: p ? type && p.type == "derivation") config.home.packages
+              )
+            );
           in ''
             # Ensure PATH includes home-manager paths
             export PATH="${config.home.profileDirectory}/bin:${packageBinPaths}:/nix/var/nix/profiles/default/bin:/usr/bin:/bin:$PATH"
+
+            # Expose nix-provided libraries for compiling runtimes from source (e.g. python-build)
+            export LIBRARY_PATH="${packageLibnPaths}''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+            export C_INCLUDE_PATH="${packageIncludePaths}''${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"
+            export LD_LIBRARY_PATH="${packageLibnPaths}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            export PKG_CONFIG_PATH="${packagePkgConfigPaths}''${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
 
             export MAKE_OPTS=-j$(nproc)
             export RUBY_CONFIGURE_OPTS="--with-libyaml-dir=${pkgs.libyaml.dev}" # This is required for ruby to discover libyaml


### PR DESCRIPTION
# Changes
- feat(nix): Add library, include, and pkgconfig paths for runtime builds
- feat(nix): Set LIBRARY_PATH, C_INCLUDE_PATH, LD_LIBRARY_PATH, PKG_CONFIG_PATH
- chore(nix): Ensure environment includes home-manager and system paths
- chore(build): Configure MAKE_OPTS for parallel compilation
- chore(ruby): Set RUBY_CONFIGURE_OPTS for libyaml discovery
- feat(asdf.nix): add skipPluginSync option to disable plugin add/update during activation
- feat(asdf.nix): conditionally skip plugin installation and update when skipPluginSync is true
- feat(asdf.nix): improve container environment support by avoiding network calls at startup
- docs(readme): add compile-time library paths environment variables explanation
- docs(readme): introduce skipPluginSync option for container/CI usage
- docs(readme): improve test and CI instructions and available checks list
- docs(readme): clarify plugin install folder is writable and usage note